### PR TITLE
Removed use of Promise

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 #### read(buffer, options)
 * `buffer` {Buffer|ArrayBuffer} - income buffer that contains data of mt940 file.
 * `options` {ReadOptions}
-* returns `Promise` with list of [Statement](src/typings.ts#L40).
+* returns array of [Statement](src/typings.ts#L40).
 
 ##### ReadOptions
 * `getTransactionId(transaction, index)` - a custom generator for transaction id. By default it's:

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,6 @@
 import md5 from './utils/md5';
 import * as parser from './parser';
 
-const invalidInputMessage: string = 'invalid input';
-
 export interface Tag {
     multiline?: boolean;
     open?: (state: State) => any;
@@ -62,7 +60,7 @@ export interface ReadOptions {
     getTransactionId (transaction: Transaction, index: number): string;
 }
 
-export function read (input: ArrayBuffer|Buffer, options?: ReadOptions): Promise<Statement[]> {
+export function read (input: ArrayBuffer|Buffer, options?: ReadOptions): Statement[] {
     let data: Uint8Array|Buffer;
 
     if (typeof Buffer !== 'undefined' && input instanceof Buffer) {
@@ -70,14 +68,12 @@ export function read (input: ArrayBuffer|Buffer, options?: ReadOptions): Promise
     } else if (typeof ArrayBuffer !== 'undefined' && input instanceof ArrayBuffer) {
         data = new Uint8Array(input);
     } else {
-        return Promise.reject(new Error(invalidInputMessage)) as any;
+        return null;
     }
 
     return parser.read(data, Object.assign({
         getTransactionId (transaction: Transaction) {
             return md5(JSON.stringify(transaction));
         }
-    }, options)).catch(() => {
-        return Promise.reject(new Error(invalidInputMessage));
-    });
+    }, options));
 }

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -35,7 +35,7 @@ function closeCurrentTag (state: State, options: ReadOptions) {
     }
 }
 
-export function read (data: Uint8Array|Buffer, options: ReadOptions): Promise<Statement[]> {
+export function read (data: Uint8Array|Buffer, options: ReadOptions): Statement[] {
     const length: number = data.length;
     const state: State = {
         pos: 0,
@@ -85,5 +85,5 @@ export function read (data: Uint8Array|Buffer, options: ReadOptions): Promise<St
 
     closeCurrentTag(state, options);
 
-    return Promise.resolve(state.statements);
+    return state.statements;
 }


### PR DESCRIPTION
I removed the use of promises because I want to use the library in a synchronous environment as well. When I checked out the code, I saw it does not need promises in order to function, because everything is synchronous and then at the end the result is wrapped in a promise.

Personally I think that the consumer of the library can wrap the call in a promise themselves, if they need to do that. This way the library itself can be used in both situations.