### PR TITLE
Modification to allow parsing of MT942

### DIFF
--- a/src/tags/transaction-info.ts
+++ b/src/tags/transaction-info.ts
@@ -11,7 +11,7 @@ const transactionInfoPattern: RegExp = new RegExp(
         '([0-9]{2})', // DD
         '([0-9]{2})?', // MM
         '([0-9]{2})?', // DD
-        '(C|D|RD|RC)',
+        '(C|D|RD|RC|EC|ED)',
         '([A-Z]{1})?', // Funds code
         '([0-9]+[,.][0-9]*)', // Amount
         '([A-Z0-9]{4})?', // Transaction code


### PR DESCRIPTION
The SWIFT FIN standards indicate that EC and ED codes are also
allowed in MT942 messages for Field 61 and Subfield 3 in
addition to C, D, RC and RD codes.

https://www.ibm.com/support/pages/apar/PM12764